### PR TITLE
Set initial select area for cropbox to largest within bounds

### DIFF
--- a/lib/assets/javascripts/papercrop.js
+++ b/lib/assets/javascripts/papercrop.js
@@ -7,7 +7,9 @@
       var attachment = $(this).attr("id").replace("_cropbox", "");
       var preview    = !!$("#" + attachment + "_crop_preview").length;
       var aspect     = $("input#" + attachment + "_aspect").val();
-      var width      = $(this).width();
+      var origWidth  = $("input[id$='_" + attachment + "_original_w']").val();
+      var origHeight = $("input[id$='_" + attachment + "_original_h']").val();
+      var initSelect = Math.max(origWidth, origHeight);
 
       if (aspect === 'false') {
         aspect = false
@@ -23,8 +25,8 @@
           ry = preview_width / coords.h;
 
           $("img#" + attachment + "_crop_preview").css({
-            width      : Math.round(rx * $("input[id$='_" + attachment + "_original_w']").val()) + "px",
-            height     : Math.round((ry * $("input[id$='_" + attachment + "_original_h']").val()) / aspect) + "px",
+            width      : Math.round(rx * origWidth) + "px",
+            height     : Math.round((ry * origHeight) / aspect) + "px",
             marginLeft : "-" + Math.round(rx * coords.x) + "px",
             marginTop  : "-" + Math.round((ry * coords.y) / aspect) + "px"
           });
@@ -39,7 +41,7 @@
       $(this).find("img").Jcrop({
         onChange    : update_crop,
         onSelect    : update_crop,
-        setSelect   : [0, 0, 250, 250],
+        setSelect   : [0, 0, initSelect, initSelect],
         aspectRatio : aspect === false ? undefined : aspect,
         boxWidth    : $("input[id$='_" + attachment + "_box_w']").val()
       }, function() {


### PR DESCRIPTION
Use the maximum of original width and height to determine initial select
area size. Prior to this, the area always started at 250x250. This
worked well for small images, but quickly becomes too small with large
images.
